### PR TITLE
Add support for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
-os: linux
+os:
+  - linux
+  - osx
+
 dist: bionic
+
 addons:
   apt:
     packages:
       - libfuse-dev
+  homebrew:
+    casks:
+      - osxfuse
+    update: true
 
 language: rust
 rust:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![allow(clippy::useless_transmute)]


### PR DESCRIPTION
This patch modifies the build steps to allow a custom type that
`osxfuse` needs. Without this the bindings cannot be generated for
macOS.