### PR TITLE
Add support for CUSE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,12 @@ pkg-config = "0.3"
 [features]
 default = ["fuse_highlevel", "fuse_lowlevel"]
 
-# Generate highlevel bindings
+# Generate highlevel fuse bindings
 fuse_highlevel = []
-# Generate lowlevel bindings
+# Generate lowlevel fuse bindings
 fuse_lowlevel = []
+# Generate lowlevel cuse bindings
+cuse_lowlevel = []
 
 # API versions
 fuse_11 = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,3 +30,12 @@ pub mod fuse_lowlevel {
     use super::*;
     include!(concat!(env!("OUT_DIR"), "/fuse_lowlevel.rs"));
 }
+
+#[cfg(feature = "cuse_lowlevel")]
+pub mod cuse_lowlevel {
+    use super::*;
+    use fuse_lowlevel::{
+        fuse_args, fuse_conn_info, fuse_file_info, fuse_pollhandle, fuse_req_t, fuse_session,
+    };
+    include!(concat!(env!("OUT_DIR"), "/cuse_lowlevel.rs"));
+}


### PR DESCRIPTION
Add bindings for definitions in [`cuse_lowlevel.h`](https://github.com/libfuse/libfuse/blob/master/include/cuse_lowlevel.h). These can be activated through the `cuse_lowlevel` feature, which is turned off by default.