### PR TITLE
Fix Mac CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
-      - staging
-      - trying
+      - '**'
     tags:
       - '*'
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
         run: cargo build --features fuse_35 --verbose
 
 
-  build-macos:
-    runs-on: macOS-latest
+  build-macos-11:
+    runs-on: macos-11
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 status = [
   "build-ubuntu-fuse2",
   "build-ubuntu-fuse3",
-  "build-macos",
+  "build-macos-11",
 ]


### PR DESCRIPTION
The `osxfuse` package is not compatible with `macos-12`. It's superseded by `macfuse` but using it makes the build fail similar to the issue described in #7.

This CR just works around the problem by replacing `macos-latest` by `macos-11` in build scripts. It's not a fix because eventually `macos-12` should be supported. I don't have access to a Mac for development though.